### PR TITLE
added smarty comment block

### DIFF
--- a/settings/language-smarty.php.cson
+++ b/settings/language-smarty.php.cson
@@ -1,0 +1,4 @@
+'.source.smarty':
+  'editor':
+    'commentStart': '{* '
+    'commentEnd': ' *}'


### PR DESCRIPTION
Hi! I've been using this package for a while and it has been bothering me that CMD + / doesn't generate a smarty comment `{* comment *}`, so I finally decided to check how it's done. It's pretty simple, so I decided to make a pull request with it.